### PR TITLE
Debian packaging updates for Geonode 2.0

### DIFF
--- a/build_geonode-geoserver-ext-deb.sh
+++ b/build_geonode-geoserver-ext-deb.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+DL_ROOT=/var/www/geoserver
+GIT_REV=$(git log -1 --pretty=format:%h)
+
+debuild
+
+if [ -d $DL_ROOT/$GIT_REV ]; then
+    rm -rf $DL_ROOT/$GIT_REV
+fi
+
+mkdir $DL_ROOT/$GIT_REV
+cp ../*.deb $DL_ROOT/$GIT_REV/.
+cp target/geoserver.war $DL_ROOT/$GIT_REV/.
+cp target/geonode-geoserver-ext-*-geoserver-plugin.zip $DL_ROOT/$GIT_REV/.
+
+# Remove all but last 4 builds to stop disk from filling up
+(ls -t|tail -n 3)|sort|uniq -u | xargs rm -rf
+
+rm -rf $DL_ROOT/latest
+ln -sf $DL_ROOT/$GIT_REV $DL_ROOT/latest

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+geoserver-geonode (2.0) precise; urgency=low
+
+  * Updates for Geonode 2.0
+
+ -- Michael Weisman <mweisman@opengeo.org>  Mon, 17 Dec 2012 11:23:45 +0800
+
 geoserver-geonode (0.3) precise; urgency=low
 
   * Initial release. (Closes: #1)

--- a/debian/control
+++ b/debian/control
@@ -13,3 +13,9 @@ Depends: tomcat7
 Description:  High performance, standards-compliant map and geospatial data server.
  GeoServer is an open source software server written in Java that allows users to share 
  and edit geospatial data. Contains GeoNode extensions.
+
+Package: geoserver-geonode-suite
+Architecture: all
+Depends: opengeo-geoserver
+Description:  GeoNode extensions for The OpenGeo Suite.
+

--- a/debian/geoserver-geonode-suite.postinst
+++ b/debian/geoserver-geonode-suite.postinst
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# start tomcat after installing geoserver
+service tomcat6 restart

--- a/debian/geoserver-geonode.postinst
+++ b/debian/geoserver-geonode.postinst
@@ -14,7 +14,7 @@ if [ "$(grep ^GEOSERVER /etc/default/tomcat7)" == "" ]; then
 fi
 
 # Fix permissions on deployed jar
-chown -R tomcat7:tomcat7 /usr/share/geoserver/geoserver
+chown -R tomcat7:tomcat7 /usr/share/geoserver/
 
 # start tomcat after installing geoserver
 service tomcat7 restart

--- a/debian/mvn_settings.xml
+++ b/debian/mvn_settings.xml
@@ -1,0 +1,3 @@
+<settings>
+ <localRepository>debian/.mvn/</localRepository>
+</settings>

--- a/debian/rules
+++ b/debian/rules
@@ -11,22 +11,30 @@
 
 %:
 	dh $@ 
+
+build:
+	# build geoserver with exts
+	mvn clean install -s ./debian/mvn_settings.xml
+
 install:
 	dh_testdir
 	dh_testroot
 	dh_prep
 	dh_installdirs
-	
 	# copy geoserver in /usr/share/geoserver
-	mkdir -p $(CURDIR)/debian/geoserver/usr/share/geoserver/
-	cp -r $(CURDIR)/target/geoserver/* $(CURDIR)/debian/geoserver/usr/share/geoserver/geoserver
+	mkdir -p $(CURDIR)/debian/geoserver-geonode/usr/share/geoserver/
+	cp -r $(CURDIR)/target/geoserver/* $(CURDIR)/debian/geoserver-geonode/usr/share/geoserver/.
 	# configure geoserver in tomcat
-	mkdir -p $(CURDIR)/debian/geoserver/etc/tomcat7/Catalina/localhost
-	echo '<Context path="/geoserver" docBase="/usr/share/geoserver/geoserver" />'  >> $(CURDIR)/debian/geoserver/etc/tomcat7/Catalina/localhost/geoserver.xml
+	mkdir -p $(CURDIR)/debian/geoserver-geonode/etc/tomcat7/Catalina/localhost
+	echo '<Context path="/geoserver" docBase="/usr/share/geoserver/" />'  >> $(CURDIR)/debian/geoserver-geonode/etc/tomcat7/Catalina/localhost/geoserver.xml
+
+	# copy geonode-ext.jar into opengeo suite geoserver
+	mkdir -p $(CURDIR)/debian/geoserver-geonode-suite/usr/share/opengeo-suite/geoserver/WEB-INF/lib/
+	unzip $(CURDIR)/target/geonode-geoserver-ext-0.3-geoserver-plugin.zip -d $(CURDIR)/debian/geoserver-geonode-suite/usr/share/opengeo-suite/geoserver/WEB-INF/lib/
 
 binary-indep: build install
 
-binary-arch: build install
+binary-arch: install
 	dh_testdir
 	dh_testroot
 	dh_installdocs


### PR DESCRIPTION
Updates to the geoserver-ext debian packges to create a standalone geoserver deb with the geonode exts as well as a deb that will install the geonode exts into the opengeo suite version of geoserver.

This also includes a jenkins job that will copy the war and geonode-ext jars to [the build server](http://build.geonode.org/geoserver/latest/) for those who want to use other platforms or install this manually.
