### PR TITLE
Copy rpms to build server

### DIFF
--- a/build_geonode-geoserver-ext-rpm.sh
+++ b/build_geonode-geoserver-ext-rpm.sh
@@ -3,5 +3,9 @@
 set -e
 
 export GEONODE_EXT_ROOT=$PWD
+DL_ROOT=/var/www/geoserver
+GIT_REV=$(git log -1 --pretty=format:%h)
 
 rpmbuild --define "_topdir ${PWD}/rpm" -bb rpm/SPECS/geoserver.spec
+
+scp -P 7777 -i ../jenkins_key.pem ../*.rpm jenkins@build.geonode.org:$DL_ROOT/$GIT_REV


### PR DESCRIPTION
This copies the rpms into place at http://build.geonode.org/geoserver.

There is also a private ami on the GeoNode dev account for building rpms (ami-b9fd74d0).
