### PR TITLE
Small fixes for geonode_authorize_layer bugs.

### DIFF
--- a/src/main/resources/org/geonode/security/geonode_authorize_layer.sql
+++ b/src/main/resources/org/geonode/security/geonode_authorize_layer.sql
@@ -101,7 +101,7 @@ if (user_name IS NOT NULL) then
       AND "security_groupobjectrolemapping"."group_id" IN (SELECT DISTINCT(group_id) FROM groups_groupmember WHERE user_id="user".id)
       AND "security_groupobjectrolemapping"."object_id" = "layer".id
       );
-    if (FOUND) then return 'gr-rw'; end if;
+    if (FOUND) then return 'group-rw'; end if;
 	end if;
 
 	-- user role, read-only
@@ -131,7 +131,7 @@ if (user_name IS NOT NULL) then
       AND "security_groupobjectrolemapping"."group_id" IN (SELECT DISTINCT(group_id) FROM groups_groupmember WHERE user_id="user".id)
       AND "security_groupobjectrolemapping"."object_id" = "layer".id
       );
-	if (FOUND) then return 'gr-ro'; end if;
+	if (FOUND) then return 'group-ro'; end if;
 	end if;
 end if;
 


### PR DESCRIPTION
- Fix a bug that prevented anonymous roles from propagating up to registered users.
- Move the generic read-only logic to come after all read-write lookups.
- Use group-\* for group permission hits vs gr-\* which is also used for generic roles.
