### PR TITLE
Use the IGNORE_COOKIES policy in the sendGET method.

### DIFF
--- a/src/main/java/org/geonode/security/HTTPClient.java
+++ b/src/main/java/org/geonode/security/HTTPClient.java
@@ -54,8 +54,7 @@ public class HTTPClient {
 
         GetMethod get = new GetMethod(url);
         get.setFollowRedirects(true);
-        // this is needed for any potential use of subdomain cookies (.domain.tld for exam
-        get.getParams().setCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
+        get.getParams().setCookiePolicy(CookiePolicy.IGNORE_COOKIES);
 
         final int numHeaders = requestHeaders == null ? 0 : requestHeaders.length / 2;
         for (int i = 0; i < numHeaders; i++) {


### PR DESCRIPTION
This is a PR to change the cookie policy for one of the methods used to authenticate Geoserver users by a request to GeoNode including a cookie.  Below are our notes from this experience. 

**The Problem**
It seems that after a few days, the geoserver-geonode-ext filter will stop behaving appropriately.  For example, a user will log into geonode with admin credentials.  Any request made to geonode will have appropriate permissions set, and the user can view all layers appropriately.  However, any request made to geoserver with the geonode cookie seems to assume anonymous permissions.  The odd thing is it that it would seem to work fine for a couple days before it stops.  When it does stop working, re-arranging the filters in geoserver, or restarting tomcat will fix the issue (even if you re-arrange the filters back to what they were). 

**More Details about this PR**
When the BROWSER_COMPATIBILITY policy is used, an invalid cookie gets stored in the HttpClient of the GeoNode Geoserver extension which causes the request to ignore any other cookies.  We were able to fix this by telling the HttpClient to ignore cookies.  The previous cookie setting was “browser compatible” which was in place to allow it to work with different subdomains.  An alternative solution would be to somehow keep it as browser compatible but clear out any stored cookies after each request.  I’m not sure how to do this, but since nobody seems to be using the subdomain feature, we went with the quick fix of ignoring cookies.  We aren’t sure how the cookie is getting stored in the HttpClient as all of the requests are going to an endpoint that does not return a Set-Cookie header.  There must be some combination of conditions that lead to the cookie being set and invalidated at some point.  
