### PR TITLE
added gs-geogit dependancy to geonode. (2.5-SNAPSHOT vs 2.5.1) 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,8 +181,6 @@
     </dependency>
 
 
-    
-
     <!-- GeoJSON module dependencies -->
     <dependency>
       <groupId>net.sf.json-lib</groupId>
@@ -198,6 +196,22 @@
       <version>${geotools.version}</version>
     </dependency>
     
+    <dependency>
+      <groupId>org.opengeo.geoserver</groupId>
+      <artifactId>gs-geogit</artifactId>
+      <version>${gsgeogit.version}</version>
+      <classifier>shaded-plugin</classifier>
+      <exclusions>
+        <exclusion><groupId>org.geogit</groupId><artifactId>geogit-core</artifactId></exclusion>
+        <exclusion><groupId>org.geogit</groupId><artifactId>geogit-geotools</artifactId></exclusion>
+        <exclusion><groupId>org.geogit</groupId><artifactId>geogit-web-api</artifactId></exclusion>
+        <exclusion><groupId>com.google.code.findbugs</groupId><artifactId>jsr305</artifactId></exclusion>
+        <exclusion><groupId>com.google.guava</groupId><artifactId>guava</artifactId></exclusion>
+        <exclusion><groupId>org.geotools</groupId><artifactId>gt-geojson</artifactId></exclusion>
+        <exclusion><groupId>org.geotools.jdbc</groupId><artifactId>gt-jdbc-spatialite</artifactId></exclusion>
+      </exclusions>
+    </dependency>    
+        
     <!--  test dependencies  -->
     <dependency>
       <groupId>junit</groupId>
@@ -219,7 +233,6 @@
       <classifier>tests</classifier>
       <version>${geoserver.version}</version>
     </dependency>
-
     <dependency>
       <groupId>com.mockrunner</groupId>
       <artifactId>mockrunner</artifactId>
@@ -272,12 +285,15 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
   <properties>
     <geotools.version>11.1</geotools.version>
     <geoserver.version>2.5.1</geoserver.version>
     <jetty.version>6.1.8</jetty.version>
+    <gsgeogit.version>2.5-SNAPSHOT</gsgeogit.version> <!-- 2.5.1 build not available so using snapshot http://repo.opengeo.org/org/opengeo/geoserver/gs-geogit/ -->  
     <maven.test.search.classdir>true</maven.test.search.classdir>
   </properties>
+  
   <profiles>
     <profile>
       <id>arcsde</id>


### PR DESCRIPTION
since gs-geogit repo http://repo.opengeo.org/org/opengeo/geoserver/gs-geogit/ doesn't have 2.5.1 available, we can either peg it to 2.5-SNAPSHOT or ask boundless to add 2.5.1 / minor releases to the repo. I went with the first option. This dependency is needed so that the geogit section under layer overview which has already been committed works. 
