### PR TITLE
set geonode URL from request

### DIFF
--- a/src/main/java/org/geonode/security/DatabaseSecurityClient.java
+++ b/src/main/java/org/geonode/security/DatabaseSecurityClient.java
@@ -51,6 +51,13 @@ public class DatabaseSecurityClient implements GeoNodeSecurityClient {
     private final DataSource dataSource;
     private final HTTPClient client;
     private final String baseUrl;
+
+    public String requestUrl;
+
+    public void setRequestUrl(String url) {
+        requestUrl = url;
+    }
+
     /**
      * Cache authentication for both cookie and user/password pairs
      */

--- a/src/main/java/org/geonode/security/DefaultSecurityClient.java
+++ b/src/main/java/org/geonode/security/DefaultSecurityClient.java
@@ -52,6 +52,9 @@ public class DefaultSecurityClient implements GeoNodeSecurityClient {
 
     private String baseUrl;
 
+    // The original request URL
+    public String requestUrl;
+
     /**
      * Caches anonymous and cookie based authorizations for a given time
      */
@@ -67,6 +70,7 @@ public class DefaultSecurityClient implements GeoNodeSecurityClient {
         this.client = httpClient;
         this.authCache = new AuthCache();
         this.baseUrl = baseUrl;
+        this.requestUrl = "";
     }
 
     /**
@@ -76,6 +80,13 @@ public class DefaultSecurityClient implements GeoNodeSecurityClient {
      */
     String getBaseUrl() {
         return baseUrl;
+    }
+
+    /**
+     * Set request URL, which will be used as the GeoNode URL if baseUrl is not set
+     */
+    public void setRequestUrl(String url) {
+        requestUrl = url;
     }
 
     /**
@@ -159,7 +170,14 @@ public class DefaultSecurityClient implements GeoNodeSecurityClient {
 
     private Authentication authenticate(final Object credentials, final String... requestHeaders)
             throws AuthenticationException, IOException {
-        final String url = baseUrl + "layers/acls";
+
+        // If baseUrl is not set, use the requesting URL
+        final String url;
+        if (baseUrl == "") {
+            url = requestUrl + "layers/acls";
+        } else {
+            url = baseUrl + "layers/acls";
+        }
 
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine("Authenticating against "+url+" with " + Arrays.toString(requestHeaders));

--- a/src/main/java/org/geonode/security/GeoNodeAuthenticationProvider.java
+++ b/src/main/java/org/geonode/security/GeoNodeAuthenticationProvider.java
@@ -33,6 +33,7 @@ public class GeoNodeAuthenticationProvider extends GeoServerAuthenticationProvid
 
     @Override
     public Authentication authenticate(Authentication authentication, HttpServletRequest request) throws AuthenticationException {
+        this.client.setRequestUrl("http://" + request.getServerName() + "/");
     	if (authentication instanceof UsernamePasswordAuthenticationToken) {
 	        UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken) authentication;
 	        String username = token.getName();

--- a/src/main/java/org/geonode/security/GeoNodeSecurityClient.java
+++ b/src/main/java/org/geonode/security/GeoNodeSecurityClient.java
@@ -21,6 +21,8 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
  */
 public interface GeoNodeSecurityClient {
 
+    public void setRequestUrl(String value);
+
     /**
      * Authenticates a user based on cookie contents
      * 

--- a/src/test/java/org/geonode/security/MockSecurityClient.java
+++ b/src/test/java/org/geonode/security/MockSecurityClient.java
@@ -32,6 +32,9 @@ public class MockSecurityClient implements GeoNodeSecurityClient {
 
     AnonymousAuthenticationToken anonymousAuth;
 
+    public void setRequestUrl(String url) {
+    }
+
     public MockSecurityClient() {
         reset();
     }


### PR DESCRIPTION
Currently, baseUrl is set in gsdata/security/auth/geonodeAuthProvider/config.xml and GeoServer uses this URL to authenticate to GeoNode.   This PR instead uses the same URL that is in the request.   As long the web server running GeoNode has a properly configured reverse proxy to GeoServer configured, then this URL is the same as the requesting URL.

The main goal of this PR is to allow a single GeoServer to serve multiple GeoNode sites.    It also has the side effect of making the baseUrl variable in config.xml unnecessary, so there is no need to set it anymore for production.

However, for backwards comparability as well as supporting development, the baseUrl variable is still used.   If it is blank (<baseUrl></baseUrl>), then the requesting URL is used.  Otherwise baseUrl is used.  This allows one to override it for development where the the URL:port will not necessarily be the same, and doesn't break any existing installations.