### PR TITLE
Fix for group authentication

### DIFF
--- a/src/main/resources/org/geonode/security/geonode_authorize_layer.sql
+++ b/src/main/resources/org/geonode/security/geonode_authorize_layer.sql
@@ -68,7 +68,7 @@ SELECT INTO ct "django_content_type"."id"
 	WHERE ("django_content_type"."model" = E'resourcebase'
 	AND "django_content_type"."app_label" = E'base' );
 
-SELECT INTO group_ids array_agg("groups_groupmember"."group_id")
+SELECT INTO group_ids array_agg("groups_groupmember"."group_id" + 1)
   FROM "groups_groupmember"
   WHERE "groups_groupmember"."user_id" = "user".id;
 


### PR DESCRIPTION
When creating a new group an entry is added to the "auth_group" table
with the first row automatically created for the anonymous group

```
auth_group
id [PK] serial, name character varying(80)
1,anonymous
```

The geonode_authorize_layer function creates the group_ids (integer[])
by querying the "groups_groupmember"."group_id" column.

The issue is that the group_id column does not account for the anonymous
group. So when GeoServer is running the prepared statement. The result
is actually "groups_groupmember"."group_id" -1. A quick fix is just to
add 1 to each value in the "group_ids", since the anonymous group will
always be the first entry.