### PR TITLE
Use LocationTech repos for GeoGig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
 			</releases>
 		</repository>
 
+               <repository>
+                       <id>repo.locationtech.org</id>
+                       <name>GeoGig Repository</name>
+                       <url>https://repo.locationtech.org/content/repositories/geogig/</url>
+               </repository>
+
 		<repository>
 			<id>boundless</id>
 			<name>Boundless Maven Repository</name>


### PR DESCRIPTION
Update the Maven dependency repository list to include LocationTech repos. As of Dec. 20, 2016, GeoGig artifacts are officially built and deployed to the LocationTech repos.